### PR TITLE
Set memory limit for Minio service in production 

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -119,6 +119,7 @@ services:
       retries: 5
     networks:
       - online_cinema_network
+    mem_limit: 128m
 
   minio_mc:
     build:


### PR DESCRIPTION
Docker Compose configuration